### PR TITLE
refactor: Rename the mis-named `configId` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An asynchronous script loader for the Brightcove Player.
     - [`applicationId`](#applicationid)
     - [`catalogSearch`](#catalogsearch)
     - [`catalogSequence`](#catalogsequence)
-    - [`configId`](#configid)
+    - [`deliveryConfigId`](#deliveryconfigid)
     - [`embedId`](#embedid)
     - [`embedOptions`](#embedoptions)
       - [`embedOptions.pip`](#embedoptionspip)
@@ -362,7 +362,7 @@ brightcovePlayerLoader({
 });
 ```
 
-#### `configId`
+#### `deliveryConfigId`
 * *Type:* `string`
 
 The Dynamic Delivery Rules Config ID to be applied to the generated embed.

--- a/demo.js
+++ b/demo.js
@@ -12,7 +12,7 @@ $(function() {
     accountId: $('#account-id'),
     adConfigId: $('#ad-config-id'),
     applicationId: $('#app-id'),
-    configId: $('#config-id'),
+    deliveryConfigId: $('#delivery-config-id'),
     embedId: $('#embed-id'),
     embedType: $('#embed-type'),
     playerId: $('#player-id'),
@@ -27,7 +27,7 @@ $(function() {
     applicationId: 1,
     catalogSearch: 1,
     catalogSequence: 1,
-    configId: 1,
+    deliveryConfigId: 1,
     embedId: 1,
     embedOptions: {
       pip: 1,

--- a/index.html
+++ b/index.html
@@ -100,9 +100,9 @@
                     </small>
                   </div>
                   <div class="form-group">
-                    <label for="config-id">Dynamic Delivery Rules Config ID</label>
-                    <input id="config-id" class="form-control" type="text" aria-describedby="config-id-help">
-                    <small id="config-id-help" class="form-text text-muted">
+                    <label for="delivery-config-id">Dynamic Delivery Rules Config ID</label>
+                    <input id="delivery-config-id" class="form-control" type="text" aria-describedby="delivery-config-id-help">
+                    <small id="delivery-config-id-help" class="form-text text-muted">
                       For more information, read <a href="https://support.brightcove.com/">TBD</a>.
                     </small>
                   </div>

--- a/src/create-embed.js
+++ b/src/create-embed.js
@@ -76,7 +76,7 @@ const createInPageEmbed = (params) => {
     applicationId: 'data-application-id',
     catalogSearch: 'data-catalog-search',
     catalogSequence: 'data-catalog-sequence',
-    configId: 'data-config-id',
+    deliveryConfigId: 'data-delivery-config-id',
     playlistId: 'data-playlist-id',
     playlistVideoId: 'data-playlist-video-id',
     videoId: 'data-video-id'

--- a/test/create-embed.test.js
+++ b/test/create-embed.test.js
@@ -37,7 +37,7 @@ QUnit.module('create-embed', function(hooks) {
       applicationId: 'app-id',
       catalogSearch: 'cat-search',
       catalogSequence: 'cat-seq',
-      configId: 'conf-id',
+      deliveryConfigId: 'conf-id',
       playlistId: 'pl-id',
       playlistVideoId: 'pl-v-id',
       videoId: 'v-id'
@@ -47,7 +47,7 @@ QUnit.module('create-embed', function(hooks) {
     assert.strictEqual(embed.getAttribute('data-application-id'), 'app-id', 'has correct data-application-id attribute');
     assert.strictEqual(embed.getAttribute('data-catalog-search'), 'cat-search', 'has correct data-catalog-search attribute');
     assert.strictEqual(embed.getAttribute('data-catalog-sequence'), 'cat-seq', 'has correct data-catalog-sequence attribute');
-    assert.strictEqual(embed.getAttribute('data-config-id'), 'conf-id', 'has correct data-config-id attribute');
+    assert.strictEqual(embed.getAttribute('data-delivery-config-id'), 'conf-id', 'has correct data-delivery-config-id attribute');
     assert.strictEqual(embed.getAttribute('data-playlist-id'), 'pl-id', 'has correct data-playlist-id attribute');
     assert.strictEqual(embed.getAttribute('data-playlist-video-id'), 'pl-v-id', 'has correct data-playlist-video-id attribute');
     assert.strictEqual(embed.getAttribute('data-video-id'), 'v-id', 'has correct data-video-id attribute');


### PR DESCRIPTION
The `configId` parameter was included erroneously and should have been `deliveryConfigId` instead.