### PR TITLE
Respect controls: false, allows to create player without controls

### DIFF
--- a/src/create-embed.js
+++ b/src/create-embed.js
@@ -67,7 +67,7 @@ const createIframeEmbed = (params) => {
  *         The DOM element that will ultimately be passed to the `bc()` function.
  */
 const createInPageEmbed = (params) => {
-  const {embedOptions} = params;
+  const {embedOptions, options} = params;
 
   // We DO NOT include the data-account, data-player, or data-embed attributes
   // here because we will be manually initializing the player.
@@ -107,7 +107,9 @@ const createInPageEmbed = (params) => {
       el.setAttribute(paramsToAttrs[key], value);
     });
 
-  el.setAttribute('controls', 'controls');
+  if (!options || options.controls !== false) {
+    el.setAttribute('controls', 'controls');
+  }
   el.classList.add('video-js');
 
   return el;

--- a/test/create-embed.test.js
+++ b/test/create-embed.test.js
@@ -29,6 +29,18 @@ QUnit.module('create-embed', function(hooks) {
     assert.notOk(embed.hasAttribute('data-embed'), 'we never include data-embed because we want to init players ourselves');
   });
 
+  QUnit.test('creates player without controls', function(assert) {
+    const embed = createEmbed({
+      refNode: this.fixture,
+      refNodeInsert: 'append',
+      options: {
+        controls: false
+      }
+    });
+
+    assert.notOk(embed.hasAttribute('controls'), 'doesn\'t have controls attribute');
+  });
+
   QUnit.test('populates certain attributes from params', function(assert) {
     const embed = createEmbed({
       refNode: this.fixture,


### PR DESCRIPTION
Looking at why there is controls when I pass option to disable controls, I found that you add controls attr without respecting named option. This small PR fixes this and adds regression test.

This should close brightcove/react-player-loader#60