### PR TITLE
feat: Add support for poster URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ An asynchronous script loader for the Brightcove Player.
     - [`playerId`](#playerid)
     - [`playlistId`](#playlistid)
     - [`playlistVideoId`](#playlistvideoid)
+    - [`poster`](#poster)
     - [`Promise`](#promise)
     - [`refNode`\*](#refnode%5C)
     - [`refNodeInsert`](#refnodeinsert)
@@ -493,6 +494,13 @@ A Video Cloud video ID or [reference ID][bc-ref-id].
 * *Type:* `string` | `number`
 
 A Video Cloud video ID that would be found in the resulting playlist specified by `playlistId`. This parameter is ignored if `playlistId` is missing.
+
+#### `poster`
+* *Type:* `string`
+
+A URL to a poster image to override that returned by the Playback API.
+
+This option is only supported when `embedType` is `'in-page'`; it is ignored  when `embedType` is `'iframe'`.
 
 #### `Promise`
 * *Type:* `Function(Function)`

--- a/demo.js
+++ b/demo.js
@@ -18,7 +18,8 @@ $(function() {
     playerId: $('#player-id'),
     mediaType: $('#media-type'),
     mediaValue: $('#media-value'),
-    options: $('#vjs-options')
+    options: $('#vjs-options'),
+    poster: $('#poster-value')
   };
 
   var allowedParams = {
@@ -45,6 +46,7 @@ $(function() {
     embedType: 1,
     playerId: 1,
     playlistId: 1,
+    poster: 1,
     videoId: 1
   };
 

--- a/index.html
+++ b/index.html
@@ -106,6 +106,13 @@
                       For more information, read <a href="https://support.brightcove.com/">TBD</a>.
                     </small>
                   </div>
+                  <div class="form-group">
+                    <label for="poster-value">Poster URL</label>
+                    <input id="poster-value" class="form-control" aria-describedby="poster-value-help"></input>
+                    <small id="poster-value-help" class="form-text text-muted">
+                      A URL to a poster can be set for in-page embeds to override the poster returned from the Playback API.
+                    </small>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/create-embed.js
+++ b/src/create-embed.js
@@ -79,6 +79,7 @@ const createInPageEmbed = (params) => {
     deliveryConfigId: 'data-delivery-config-id',
     playlistId: 'data-playlist-id',
     playlistVideoId: 'data-playlist-video-id',
+    poster: 'poster',
     videoId: 'data-video-id'
   };
 

--- a/test/create-embed.test.js
+++ b/test/create-embed.test.js
@@ -40,6 +40,7 @@ QUnit.module('create-embed', function(hooks) {
       deliveryConfigId: 'conf-id',
       playlistId: 'pl-id',
       playlistVideoId: 'pl-v-id',
+      poster: 'pstr',
       videoId: 'v-id'
     });
 
@@ -50,6 +51,7 @@ QUnit.module('create-embed', function(hooks) {
     assert.strictEqual(embed.getAttribute('data-delivery-config-id'), 'conf-id', 'has correct data-delivery-config-id attribute');
     assert.strictEqual(embed.getAttribute('data-playlist-id'), 'pl-id', 'has correct data-playlist-id attribute');
     assert.strictEqual(embed.getAttribute('data-playlist-video-id'), 'pl-v-id', 'has correct data-playlist-video-id attribute');
+    assert.strictEqual(embed.getAttribute('poster'), 'pstr', 'has correct data-playlist-video-id attribute');
     assert.strictEqual(embed.getAttribute('data-video-id'), 'v-id', 'has correct data-video-id attribute');
   });
 


### PR DESCRIPTION
Adds support for a `poster` option, which sets the value as a `poster` attribute on the embed.
Updates docs and test.