### PR TITLE
fix: Storing player script also with accountId to avoid duplicates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -174,8 +174,11 @@ const resolveRefNode = (refNode) => {
  *         A success object whose `ref` is a player.
  */
 const initPlayer = (params, embed, resolve, reject) => {
-  const {embedId, playerId} = params;
-  const bc = window.bc[`${playerId}_${embedId}`] || window.bc;
+  const {embedId, playerId, accountId} = params;
+  const playerKey = `${accountId}_${playerId}_${embedId}`;
+  const bc = window.bc[playerKey] || window.bc;
+
+  window.bc[playerKey] = window.bc[playerKey] ? window.bc[playerKey] : bc;
 
   if (!bc) {
     return reject(new Error(`missing bc function for ${playerId}`));


### PR DESCRIPTION
Currently we are storing players scripts only with `playerId` and `embedId`, which result in loading the wrong script when you try to load a player with same params but different `accountId`. This later produces a 401 error when catalog request is made for a specific `videoId`, but with the wrong account.

Changes include storing scripts with `accountId` param also as a key.