### PR TITLE
feat: Support an in-page embed without controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ An asynchronous script loader for the Brightcove Player.
     - [`deliveryConfigId`](#deliveryconfigid)
     - [`embedId`](#embedid)
     - [`embedOptions`](#embedoptions)
+      - [`embedOptions.controls`](#embedoptionscontrols)
       - [`embedOptions.pip`](#embedoptionspip)
       - [`embedOptions.playlist`](#embedoptionsplaylist)
       - [`embedOptions.responsive`](#embedoptionsresponsive)
@@ -378,6 +379,12 @@ The Brightcove Player [embed ID][bc-embed-id] for the player. The default value 
 * *Type:* `Object`
 
 Used to provide certain options for embed generation. These include:
+
+##### `embedOptions.controls`
+* *Type:* `boolean`
+* *Default:* `true`
+
+If `false`, the player will be created with control disabled. Supported for in-page (advanced) embeds only.
 
 ##### `embedOptions.pip`
 * *Type:* `boolean`

--- a/demo.js
+++ b/demo.js
@@ -31,6 +31,7 @@ $(function() {
     deliveryConfigId: 1,
     embedId: 1,
     embedOptions: {
+      controls: 1,
       pip: 1,
       playlist: {
         legacy: 1
@@ -58,7 +59,8 @@ $(function() {
     playlist: $('#eo-playlist'),
     responsive: $('#eo-resp'),
     tagName: $('#eo-tag-name'),
-    unminified: $('#eo-unmin')
+    unminified: $('#eo-unmin'),
+    controls: $('#eo-controls')
   };
 
   function isObj(v) {

--- a/index.html
+++ b/index.html
@@ -208,6 +208,10 @@
                     <input id="eo-pip" class="form-check-input" type="checkbox">
                     <label class="form-check-label" for="eo-pip">Picture-in-Picture</label>
                   </div>
+                  <div class="form-check form-group">
+                    <input id="eo-controls" class="form-check-input" type="checkbox" checked>
+                    <label class="form-check-label" for="eo-controls">Controls</label>
+                  </div>
                   <div class="form-group">
                     <label class="form-check-label" for="eo-playlist">Playlist</label>
                     <select id="eo-playlist" class="form-control">

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,7 +3662,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3683,12 +3684,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3703,17 +3706,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3830,7 +3836,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3842,6 +3849,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3856,6 +3864,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3863,12 +3872,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3887,6 +3898,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3967,7 +3979,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3979,6 +3992,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4064,7 +4078,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4100,6 +4115,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4119,6 +4135,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4162,12 +4179,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/create-embed.js
+++ b/src/create-embed.js
@@ -108,7 +108,9 @@ const createInPageEmbed = (params) => {
       el.setAttribute(paramsToAttrs[key], value);
     });
 
-  el.setAttribute('controls', 'controls');
+  if (!embedOptions || embedOptions.controls !== false) {
+    el.setAttribute('controls', 'controls');
+  }
   el.classList.add('video-js');
 
   return el;

--- a/test/create-embed.test.js
+++ b/test/create-embed.test.js
@@ -217,6 +217,18 @@ QUnit.module('create-embed', function(hooks) {
     }
   });
 
+  QUnit.test('controls', function(assert) {
+    const embed = createEmbed({
+      refNode: this.fixture,
+      refNodeInsert: 'append',
+      embedOptions: {
+        controls: false
+      }
+    });
+
+    assert.notOk(embed.hasAttribute('controls'), this.fixture, 'has no controls attribute');
+  });
+
   QUnit.test('pip', function(assert) {
     const embed = createEmbed({
       refNode: this.fixture,


### PR DESCRIPTION
Adds `controls` as a supported property in `embedOptions`. Does not add `controls` attribute when set to `false`.
Updates test and docs.

Fixes brightcove/react-player-loader/issues/60
Replaces #65