### PR TITLE
Preserve error details in `script.onerror`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -260,8 +260,10 @@ const loadPlayer = (params, resolve, reject) => {
 
   script.onload = () => initPlayer(params, embed, resolve, reject);
 
-  script.onerror = () => {
-    reject(new Error('player script could not be downloaded'));
+  script.onerror = (...onerrorArgs) => {
+    const error = new Error('player script could not be downloaded');
+    error.details = { ...onerrorArgs };
+    reject(error);
   };
 
   script.async = true;


### PR DESCRIPTION
## Description

Currently this `onerror` handler discards potentially valuable information from the original error (`event`, `source`, `lineno`, `colno`, `error`). My change adds this information via a `details` property.

## Motivation

In our app, we get a surprising number of `player script could not be downloaded` errors and this change would allow devs to understand the issue better.

Thanks!